### PR TITLE
Adds Logic to Find Static Files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,36 @@
+import os
+
 from setuptools import setup
 from io import open
 from pt_lightning_sphinx_theme import __version__
+
+
+def package_files(directory:str):
+    """
+    Traverses target directory recursivery adding file paths to a list.
+    Original solution found at:
+
+        * https://stackoverflow.com/questions/27664504/\
+            how-to-add-package-data-recursively-in-python-setup-py
+
+    Parameters
+    ----------
+    directory: str
+        Target directory to traverse.
+
+    Returns
+    -------
+    paths: list
+        List of file paths.
+    
+    """ 
+    paths = []
+    for (path, directories, filenames) in os.walk(directory):
+        for filename in filenames:
+            paths.append(os.path.join('..', path, filename))
+
+    return paths
+
 
 setup(
     name = 'pt_lightning_sphinx_theme',
@@ -17,11 +47,8 @@ setup(
     package_data={'pt_lightning_sphinx_theme': [
         'theme.conf',
         '*.html',
-        'static/css/*.css',
-        'static/js/*.js',
-        'static/fonts/*.*',
-        'static/images/*.*',
-        'theme_variables.jinja'
+        'theme_variables.jinja',
+        *package_files('pt_lightning_sphinx_theme/static')
     ]},
     entry_points = {
         'sphinx.html_themes': [


### PR DESCRIPTION
I noticed that static files in nested directories--e.g. static/fonts, static/js/vendor--were not being included when this theme was installed as a package. This caused issues with the theme not loading required JavaScript to work property (and also not displaying the right fonts). (One could see this by inspecting the network calls the theme was making and getting lots of 404 errors.)

I've added logic here to automatically add all files in the `static` directory to the theme package. The logic I added does that by recursively traversing the `static` directory and adding all found files' relative paths to the setup import.

----

This PR essentially contains the same code of https://github.com/PyTorchLightning/lightning_sphinx_theme/pull/2, but with a cleaner git history. 