### PR TITLE
Update deprecated sass calcs

### DIFF
--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -675,7 +675,7 @@
   @include sphinx-medium-size {
     left: 0;
     display: flex;
-    height: $desktop_header_height / 2;
+    height: calc($desktop_header_height / 2);
     padding-left: 0;
     width: 100%;
     position: absolute;

--- a/scss/shared/_variables.scss
+++ b/scss/shared/_variables.scss
@@ -64,7 +64,7 @@ $baseurl: "";
 }
 
 @function rem($px) {
-  @return ($px / 16px) * 1rem;
+  @return calc($px / 16px) * 1rem;
 }
 
 @mixin clearfix {


### PR DESCRIPTION
Otherwise grunt tasks throw when installed from scratch with the latest versions. (grunt-cli v1.4.3, grunt v1.4.1, sass 1.51.0 compiled with dart2js 2.16.2)

![Screenshot 2022-05-12 at 09 44 36](https://user-images.githubusercontent.com/87709526/168036877-82c11284-8ee8-4005-9a39-159b96b66f2c.png)
 